### PR TITLE
add no cache to force theta binary download

### DIFF
--- a/docker/build_and_start_guardian.sh
+++ b/docker/build_and_start_guardian.sh
@@ -2,7 +2,7 @@
 
 # build the Theta Guardian Node image
 # this is essentially a no-op if the image already exists
-docker build -t theta_guardian_node:1.0 .
+docker build --no-cache -t theta_guardian_node:1.0 .
 
 # In launching this, we need to provide a password to the container
 #


### PR DESCRIPTION
add --no-cache to docker build such that if we rebuild the docker on the same machine as prior, it will force the curl download of the theta binaries. The theta binaries do not carry the version in the filename and it is assumed "latest" when we curl it. Updating to GN 3.4.0, yields the same curl download request, so we should force it here.